### PR TITLE
Upgrade Quarkus-960 in order to support external registries

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="74e0fea3-5821-4c2b-936c-599be2495c96" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="23Yi7m4mnEgB1WrZyiRsO6AmZ56" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="74e0fea3-5821-4c2b-936c-599be2495c96" name="Changes" comment="" />
+      <created>1641917255331</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1641917255331</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/QUARKUS-960.md
+++ b/QUARKUS-960.md
@@ -10,7 +10,7 @@ So, the goal is to verify proper functionality of the new Quarkus CLI tool.
 The Quarkus CLI is compatible with Maven, Gradle and Jbang tools, however RHBQ is only focused on Maven, so Gradle and Jbang will be covered as part of the test coverage in upstream.
 
 Test development will focus on the supported features scoped for RHBQ 2.2:
-- Create applications (with a set of extensions)
+- Create applications (with a set of extensions) and pointing to a specific platform
 - List extensions
 - Build existing Quarkus applications on JVM
 - Build existing Quarkus applications on Native (also using container configuration and builder images)


### PR DESCRIPTION
Quarkus Cli support for registry / composable stream poms

For exmaple:

```
quarkus create app --platform-bom io.quarkus:quarkus-bom:999-SNAPSHOT 
```