### PR TITLE
Upgrade Quarkus-640 - Apicurio serdes

### DIFF
--- a/QUARKUS-640.md
+++ b/QUARKUS-640.md
@@ -11,6 +11,7 @@ Following actions were taken to ensure test coverage and automation for reactive
  - Kafka Streams with JSON body messages and windowed.
  - Tested over Kafka Strimzi and RH AMQ Streams.
  - Platform OpenShift, Java 11.
+ - Apicurio serdes (serializers/deserializers)
 
 ### Impact on testsuites and testing automation:
  - OpenShift TS framework needs to be enhanced to support Kafka on OpenShift


### PR DESCRIPTION
Missing a reference to apicurio serdes as a part of the testing scope