### PR TITLE
Update JDK17 / Quarkus-728 test plan

### DIFF
--- a/QUARKUS-1397.md
+++ b/QUARKUS-1397.md
@@ -1,0 +1,30 @@
+# Quarkus-1397 - Dev preview for Java 17 in Native mode
+
+JIRA link: https://issues.redhat.com/browse/QUARKUS-1397
+
+This test plan cover JDK17 Mandrel dev preview Quarkus integration.
+
+## Related test plans
+
+ - [QUARKUS-728](QUARKUS-728)
+
+## Scope of the testing
+
+Test development will focus on
+- Current native scenarios must work with Java 17
+
+### Impact on testsuites and testing automation:
+
+- Native daily GitHub builds will cover Mandrel community JDK17 container image `ubi-quarkus-mandrel:21.3-java17`
+- Mandrel image based on Java 17 (`quarkus/mandrel-21-jdk17-rhel8`) is in a technical preview stage and is going to be covered by extended platform testing as a subset of testing coverage.
+- Native JDK17 will be covered by the following Jenkins jobs:
+  - rhbq-2.7-extended-platform-testing-trigger
+     - rhbq-2.7-baremetal-ts-native
+- Native pipelines are expensive in terms of time execution and also in CPU and memory usage. The instance type that we are gonna use is xlarge and ideally, lab capacity should be increased in order to cover new pipelines that are gonna be created. 
+## Getting familiar with the feature
+Following actions were taken to ensure familiarity:
+ - Exploratory testing as OCP native scenarios 
+ - Ensure good user experience and simplicity of use
+
+## Contacts
+* Tester: Pablo Gonzalez <pagonzal@redhat.com>

--- a/QUARKUS-728.md
+++ b/QUARKUS-728.md
@@ -4,11 +4,18 @@ JIRA link: https://issues.redhat.com/browse/QUARKUS-728
 
 The goal is to verify OpenJDK 17 integration
 
+## Related test plans
+
+ - [QUARKUS-1397](QUARKUS-1397)
+
 ## Scope of the testing
 Test development will focus on  
  - New specifict scenarios will be created to cover the integration of new objects as “sealed” or “records” classes with several extensions as Hibernate or RESTEasy.
  - Current scenarios must work with Java 17
  - S2I (source to image) must works with Java 17
+ - Non-S2I must work with Java 17
+ - Code Quarkus could create an application pointing to Java 17
+ - Quarkus-CLI and quarkus-maven-plugin must be able to create an application with Java 17
  - JDK17 brings a lot of interesting [JEPs](http://openjdk.java.net/jeps/1)  implemented since JDK 11, and these ones are the selected ones to be covered by this test plan:
     * [JEP 359, 384, 395: Records](https://openjdk.java.net/jeps/395)
     * [JEP 325, 354, 361: Switch Expressions](https://openjdk.java.net/jeps/361)
@@ -20,8 +27,7 @@ Test development will focus on
     * [JEP 371: Hidden Classes](https://openjdk.java.net/jeps/371)
 
 ### Impact on testsuites and testing automation:
- - Ensure this coverage works in JVM mode
- - NATIVE mode is not required in Java 17 
+ - Ensure this coverage works in JVM and native mode
  - Ensure this coverage works in Openshift (S2I)
  - New test suite will be created in order to develop specifict Java 17 scenarios
  - Following RHBQ 2.x testing strategy Java 11 will be our primary platform that will support all the defined platforms, but Java 17 must also support a subsequent of these platforms:
@@ -42,7 +48,7 @@ Test development will focus on
      - rhbq-2.2-rhel8-openshift-ts-jvm-ocp
   
  - Lab capacity should be ideally increased by 50% in terms of CPU and RAM memory, if that doesn't happen the execution time of testing will be prolonged, almost doubled.
- - New Jenkins slaves that will run Java 17 pipelines will have OpenJDK 17 installed preferably an RHEL OpenJDK distribution but if doesn't exist because is an early stage version then we will use an SDKman distribution
+ - New Jenkins slaves that will run Java 17 pipelines will have OpenJDK 17 installed preferably an RHEL OpenJDK distribution.
  - Github actions should be configured in order to run tests over Java 11 and 17
     
 ## Getting familiar with the feature


### PR DESCRIPTION
JDK 17 is going to be tech-preview supported in the next product release. This PR adds some amends to the existing JDK17 test plan. 