### PR TITLE
Add  "Related test plans" subject to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Use file name based on RFE id, for example QUARKUS-123.md
 ## Links to the resources
  - Provide links to the GH / JIRA issue
  - Provide links to the Chatroom / Forum design discussions
+ - Provide links to other related test plans if applicable 
 
 ## Scope of the testing
  - Define scope of the testing


### PR DESCRIPTION
Sometimes a test plan is directly linked to other test plans. In those cases, we have created a new section called "Related test plans" where you can link your test plan with the related ones. 