### PR TITLE
QUARKUS-2453 / QUARKUS-2527 - Deprecate quarkus-reactive-routes extension

### DIFF
--- a/QUARKUS-2453.md
+++ b/QUARKUS-2453.md
@@ -1,0 +1,15 @@
+# QUARKUS-2453 - Deprecate quarkus-reactive-routes extension
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-2453
+
+Deprecate `quarkus-reactive-routes` extension starting with RHBQ 2.13, for RHBQ 2.7 the extension is on supported level.
+
+## Scope of the testing
+
+Ensure `deprecated` redhat-support label is rendered for quarkus-reactive-routes extension on https://code.quarkus.redhat.com/ pre-stage instance.
+
+Marete and StartStopTS need to be checked and adjusted to reflect the drop of the Supported level to the Deprecated one.
+Main Quarkus QE TS won't be adjusted, test coverage needs to stay in place till the support is dropped for good.
+
+### Impact on resources
+- No impact on resources for TS

--- a/QUARKUS-2527.md
+++ b/QUARKUS-2527.md
@@ -1,0 +1,14 @@
+# QUARKUS-2527 - Add support for deprecated label to code.quarkus.redhat.com
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-2527
+
+Add support for `deprecated` label for `redhat-support` to code.quarkus.redhat.com.
+
+## Scope of the testing
+
+Ensure `deprecated` label for `redhat-support` is available in Filters section on https://code.quarkus.redhat.com/ pre-stage instance.
+
+Ensure `deprecated` redhat-support label is rendered for quarkus-reactive-routes extension on https://code.quarkus.redhat.com/ pre-stage instance.
+
+### Impact on resources
+- No impact on resources for TS


### PR DESCRIPTION
QUARKUS-2453 / QUARKUS-2527 - Deprecate quarkus-reactive-routes extension

- https://issues.redhat.com/browse/QUARKUS-2453 - Deprecate quarkus-reactive-routes extension
- https://issues.redhat.com/browse/QUARKUS-2527 - Add support for deprecated label to code.quarkus.redhat.com
