### PR TITLE
Fix QUARKUS-2349: Fully support Java 17 and drop Java 11 for Native application

### DIFF
--- a/QUARKUS-2349.md
+++ b/QUARKUS-2349.md
@@ -20,7 +20,7 @@ Test development will focus on
   
 ### Impact on testsuites and testing automation:
 
-- GraalVM/Mandrel JDK17 native builder images are going to be used to compile Quarkus native application regardless of whether the application runs on java 11 or 17
+- GraalVM/Mandrel JDK17 native builder images are going to be used to compile Quarkus native application
 - Native daily GitHub builds will cover GraalVM and Mandrel community JDK17 native builder images
 -  `ubi-quarkus-native-image:22.2-java17` and `ubi-quarkus-mandrel:22.2-java17` now
 -  targeting `ubi-quarkus-native-image:22.3-java17` and `ubi-quarkus-mandrel:22.3-java17` (when available) for Quarkus 2.13.z releases.


### PR DESCRIPTION
We are not going to cover Quarkus app over JDK11 in native mode. All coverage is going to be done over JDK 17. This commit remove a partial statement that could be misunderstood.