### PR TITLE
Adjust QUARKUS-2736 plan - cover Hibernate legacy behavior in Test Suite

### DIFF
--- a/QUARKUS-2736.md
+++ b/QUARKUS-2736.md
@@ -100,7 +100,7 @@ and upstream integration modules.
 
 ## Impact on test suites and test environment
 
-Beefy Scenarios should cover newly introduced configuration properties that enforces legacy behavior and provides
+Quarkus Test Suite should cover newly introduced configuration properties that enforces legacy behavior and provides
 smooth migration.
 
 The SameSite cookies added by Jakarta REST Services 3.1 will require one unit test with multiple HTTP requests.


### PR DESCRIPTION
Addresses this comment - https://github.com/quarkus-qe/quarkus-test-plans/pull/136#discussion_r1131218697. Hibernate legacy behavior should be verified by the Quarkus Test Suite.