### PR TITLE
Add test plan for QUARKUS-3535

### DIFF
--- a/QUARKUS-3535.md
+++ b/QUARKUS-3535.md
@@ -1,0 +1,34 @@
+# QUARKUS-3535 - Add a metric for rejected submissions to the pool in RHBQ 3.2
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-3535
+
+PR: https://github.com/quarkusio/quarkus/pull/35541
+
+Upstream issue: https://github.com/quarkusio/quarkus/issues/35540
+
+One simple way to deal with load shedding is to limit thread pool queue size, however
+that also brings downside of limited number of requests that can be handled of time.
+Applications need to measure rejected pool submissions metric so that load can be spread.
+
+## Scope of the testing
+ * Run Quarkus application with limited thread pool queue and maximal number of thread
+ * Assert thread pool configuration properties have affect and under big load pool submissions are rejected
+ * Run test on baremetal only as feature is related to JVM wherever it is run
+ * Run test in the JVM mode only as rejection is next to impossible reproduce in native mode
+
+## Existing test coverage
+* We already test in the QE Test Suite HTTP Vert.x module ability to retrieve metrics in OpenShift and native mode.
+
+### Impact on test suites and testing automation
+ * New test will verify metric for rejected submissions to the Vert.x worker thread pool
+
+### Impact on resources
+ * One baremetal test execution in JVM mode
+ * Test will not require any containers and will be executed very fast
+ * Overall QE Test Suite execution time will be greater roughly by 10 seconds
+
+## Contacts
+* Tester: Michal Vavřík <mvavrik@redhat.com>
+
+## References
+- [ExecutorService should expose metrics](https://github.com/quarkusio/quarkus/issues/34998)


### PR DESCRIPTION
### Links

JIRA: https://issues.redhat.com/browse/QUARKUS-3535

Quarkus documentation: https://quarkus.io/guides/all-config#quarkus-core_quarkus.thread-pool.queue-size

Native mode assumptions go down to the https://quarkus.io/guides/native-reference#multi-thread and the fact that I didn't really manage to reproduce it in native mode. Maybe it is safe to say that if I can't reproduce it here https://github.com/quarkus-qe/quarkus-test-suite/pull/1551 then users are less likely to be affected by any related issue.

I realize that Keycloak team had issues in OpenShift, but that really goes down to where big load happens, so it is not important whether you run this test on baremetal or OpenShift as there is no relevance of these changes to cloud environment.

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
