### PR TITLE
QQE-343 Quarkus and non JSON payload in REST endpoints

### DIFF
--- a/QQE-343.md
+++ b/QQE-343.md
@@ -1,0 +1,58 @@
+# QQE-343- Quarkus and non-JSON payload in REST endpoints
+
+JIRA: https://issues.redhat.com/browse/QQE-343
+PR: https://github.com/quarkus-qe/quarkus-test-suite/pull/1599
+
+## Scope of the testing
+The test scope includes validating Quarkus's capability to handle non-JSON payloads in REST endpoints.
+For this testing scope I will choose some of them, for instance XML, YAML and images. 
+Tests will cover both JVM and Native mode executions.
+#### Test scenarios
+
+        1. XML Payload Scenario:
+            * Verify the endpoint's ability to consume and produce XML payloads.
+            * Send a request with an XML payload to the endpoint.
+            * Validate the response, ensuring it matches the expected XML Schema.
+    
+        2. YAML Payload Scenario:
+            * Check the endpoint's ability to return payload from a YAML file.
+            * Send a request with a YAML payload from a file to an endpoint.
+            * Validate the response, ensuring it matches the expected YAML content.
+    
+        3. Image Payload Scenario:
+            * Verify the endpoint's ability to return an image by making a GET request.
+            * Send an image in a multipart form to the endpoint.
+            * Check the endpoint's handling of image upload as part of a multipart form by making a POST request.
+### Impact on testsuites and testing automation:
+New tests will be added inside [http/http-advance-reactive](https://github.com/quarkus-qe/quarkus-test-suite/tree/main/http/http-advanced-reactive) module.
+
+### Impact on resources:
+After the new test classes introduced in http/http-advanced-reactive module the execution in JVM was only increased by seconds:
+
+`````[INFO] Quarkus QE TS: HTTP: advanced-reactive ............. SUCCESS [03:07 min]`````
+
+(result from https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/7673741087/job/20917606017?pr=1599).
+
+## Getting familiar with the feature
+
+Following actions were taken to ensure familiarity:
+- Experiment with Quarkus REST functionalities for providing and consuming non-JSON payload (XML, YAML, images)
+- Take a look and understand the Quarkus REST guides related to.
+
+
+##  Future considerations
+To handle YAML files, it was necessary to create a YAML Provider that implements MessageBodyReader and MessageBodyWriter to map the DTO used,
+enabling the serialization and deserialization of YAML data for the DTO (CityListDTO).
+Essentially, MessageBodyReader/MessageBodyWriter allows for the conversion of YAML streams into Java objects and vice versa.
+See [YamlProvider class](https://github.com/quarkus-qe/quarkus-test-suite/blob/main/http/http-advanced-reactive/src/main/java/io/quarkus/ts/http/advanced/reactive/YamlProvider.java) for more details.
+
+
+## References
+- Feature epic: [HTTP module / REST use-cases - Development topics](https://issues.redhat.com/browse/QQE-376)
+- [RestEasy Reactive guide](https://quarkus.io/guides/resteasy-reactive)
+- [Rest Client guide](https://quarkus.io/guides/rest-client-reactive)
+- [Reactive resources](https://quarkus.io/guides/getting-started-reactive#reactive-resource)
+- [Readers and Writers: mapping entities and HTTP bodies](https://quarkus.io/guides/resteasy-reactive#readers-and-writers-mapping-entities-and-http-bodies)
+
+## Contact
+- Tester: Jose Carranza  <jcarranz@redhat.com>


### PR DESCRIPTION
### Links

JIRA:
[Quarkus and non JSON payload in REST endpoints](https://issues.redhat.com/browse/QQE-343)

Quarkus documentation: 
[Resteasy-reactive#xml-serialisation](https://quarkus.io/guides/resteasy-reactive#xml-serialisation)
[Reactive-jax-rs-resources guide](https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources )
[Resteasy-reactive#readers-and-writers-mapping-entities-and-http-bodies](https://quarkus.io/guides/resteasy-reactive#readers-and-writers-mapping-entities-and-http-bodies)

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
