### PR TITLE
Run Native jobs on JDK 21 as well

### DIFF
--- a/QUARKUS-2994.md
+++ b/QUARKUS-2994.md
@@ -15,9 +15,8 @@ JIRA link: https://issues.redhat.com/browse/QUARKUS-2994
 * Temurin JVM 21 and OpenJDK 21 need to be added as JDKs to Quarkus QE Jenkins
 * Temurin JVM 21 and OpenJDK 21 have to be added as JVMs to Polarion
 * Bare metal Linux jobs in extended platform testing need to be extended to run with both Temurin 21 and OpenJDK 21.
-  * This affects JVM mode only.
 * Bare metal Windows jobs (JVM on AWS) in extended platform testing need to be extended to run with Temurin 21.
-* OpenShift JVM job needs to use OpenJDK 21 (together with existing 17) instead of OpenJDK 11
+* OpenShift jobs need to use OpenJDK 21 (together with existing 17) instead of OpenJDK 11
   * We also should use S2I build image based on JDK 21 there
 * Two quickstart jobs (Linux and Windows) should be added/repurposed from 11 in general or extended pipeline
 * Add a job for running on ARM


### PR DESCRIPTION
### Links

Previous PR: https://github.com/quarkus-qe/quarkus-test-plans/pull/155
Updates required, since default native image for RHBQ 3.8 is registry-proxy.engineering.redhat.com/rh-osbs/quarkus-mandrel-for-jdk-21-rhel8:23.1


### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
