### PR TITLE
Add test plan of JSON payloads in Quarkus REST endpoints

### DIFF
--- a/QQE-379.md
+++ b/QQE-379.md
@@ -1,0 +1,80 @@
+# QQE-379 - HTTP module / REST use-cases - Development topics - JSON payload
+## Links
+
+Jira : [QQE-379](https://issues.redhat.com/browse/QQE-379)
+
+TD: https://github.com/quarkus-qe/quarkus-test-suite/pull/1890
+
+This test plan outlines the testing for different JSON payloads in Quarkus REST endpoints.
+It aims to ensure the correct handling of JSON data in various scenarios, including successful processing, invalid payloads, error handling, and complex data structures.
+
+## Scope of the testing
+
+* The test coverage will be verified for environments:  JVM, native mode and Openshift.
+* Libraries used: quarkus-rest-jackson, quarkus-rest-jsonb
+* Payloads: valid, invalid, large, complex, missing/incorrect/empty/null data types, special characters.
+
+### What to test
+
+#### Successful JSON payload processing:
+Verify that Quarkus REST endpoints successfully process valid JSON payloads.
+  - **Payload:** simple json file. 
+  - **HTTP Method:** `POST`
+  - **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured JSON libraries (quarkus-rest-jackson, quarkus-rest-jsonb).
+  - **HTTP Status Code:** Expect `201 Created` upon successful payload processing.
+  - **Response Content:** Validate that the response contains the expected message.
+
+#### Check large JSON with complex structures payload processing:
+Verify that the application can efficiently process large JSON payloads containing nested objects, arrays, and various data types without issues.
+- **Payload:** large json file.
+- **HTTP Method:** `POST` and `GET`
+- **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured JSON libraries (quarkus-rest-jackson, quarkus-rest-jsonb).
+- **HTTP Status Code:** Expect `201 Created` upon successful payload processing.
+- **Response Content:** Validate that the response contains the expected message.
+
+####  Handling invalid JSON payloads:
+Test how the application responds to malformed or invalid JSON requests
+ensuring appropriate error responses are returned.
+- **Payload:** json file without commas between objects, extra strings, etc.
+- **HTTP Method:** `POST`
+- **HTTP Status Code:** Expect 400 Bad request for invalid payloads.
+
+#### Handling missing or incorrect data types:
+Validate the behavior when required JSON fields are missing or have incorrect, empty, null data types,
+ensuring proper error handling.
+- **Payload:** json file with empty and null json object's fields.
+- **HTTP Method:** `POST`
+- **HTTP Status Code:** Expect 400 Bad request for incorrect or missing data types.
+
+#### Testing with special characters JSON payload :
+Validate the application's response to JSON payload containing special characters.
+- **Payload:** Create a JsonObject with special characters.
+- **HTTP Method:** `POST`
+- **HTTP Status Code:** Expect 201 Created.
+
+
+#### Testing of incorrect Content-Type : 
+Test requests with incorrect Content-Type headers should fail gracefully.
+- **HTTP Method:** `POST`
+- **HTTP Status Code:** Expect 415 Unsupported Media Type.
+
+## Getting Familiar with the Feature:
+
+- Review Quarkus documentation: understand the Quarkus REST guides and its JSON serialization/deserialization mechanisms.
+- Explore RESTEasy reactive: Dive into the specifics of RESTEasy Reactive, the underlying implementation of Quarkus REST, paying attention to its handling of JSON payloads and integration with Jackson or JSON-B.
+- Examine code examples: Analyze code provided in the Quarkus repositories to gain practical insights.
+- Hands-on experimentation: Create sample Quarkus REST endpoints and experiment with different JSON payloads to observe the behavior.
+
+
+## Links to the resources
+- [Writing JSON REST Services ](https://quarkus.io/guides/rest-json)
+- [Customizing the ObjectMapper in REST Client Jackson](https://quarkus.io/guides/rest-client#customizing-the-objectmapper-in-rest-client-jackson)
+- [Creating the first JSON REST service](https://quarkus.io/guides/resteasy#creating-the-first-json-rest-service)
+
+### Impact on resources
+- On JVM, tests increase execution time of the module http-advanced-reactive up to 1 minutes.
+- On Native, JsonJacksonPayloadIT time execution takes 03:17 min and JsonBPayloadIT 02:49 min.
+- On Openshift, tests takes 02:31 min.
+
+## Contacts
+- Tester: Jose Carranza <jcarranz@redhat.com>


### PR DESCRIPTION
### Links

JIRA:
 [QQE-379](https://issues.redhat.com/browse/QQE-379)

Quarkus documentation:
- [Writing JSON REST Services ](https://quarkus.io/guides/rest-json)
- [Customizing the ObjectMapper in REST Client Jackson](https://quarkus.io/guides/rest-client#customizing-the-objectmapper-in-rest-client-jackson)
- [Creating the first JSON REST service](https://quarkus.io/guides/resteasy#creating-the-first-json-rest-service)
### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
