### PR TITLE
Refactor of QQE-379.md dropping Jackson approach

### DIFF
--- a/QQE-379.md
+++ b/QQE-379.md
@@ -11,7 +11,7 @@ It aims to ensure the correct handling of JSON data in various scenarios, includ
 ## Scope of the testing
 
 * The test coverage will be verified for environments:  JVM, native mode and Openshift.
-* Libraries used: quarkus-rest-jackson, quarkus-rest-jsonb
+* Libraries used: quarkus-rest-jsonb
 * Payloads: valid, invalid, large, complex, missing/incorrect/empty/null data types, special characters.
 
 ### What to test
@@ -20,7 +20,7 @@ It aims to ensure the correct handling of JSON data in various scenarios, includ
 Verify that Quarkus REST endpoints successfully process valid JSON payloads.
   - **Payload:** simple json file. 
   - **HTTP Method:** `POST`
-  - **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured JSON libraries (quarkus-rest-jackson, quarkus-rest-jsonb).
+  - **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured Quarkus JSON-B library (quarkus-rest-jsonb).
   - **HTTP Status Code:** Expect `201 Created` upon successful payload processing.
   - **Response Content:** Validate that the response contains the expected message.
 
@@ -28,7 +28,7 @@ Verify that Quarkus REST endpoints successfully process valid JSON payloads.
 Verify that the application can efficiently process large JSON payloads containing nested objects, arrays, and various data types without issues.
 - **Payload:** large json file.
 - **HTTP Method:** `POST` and `GET`
-- **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured JSON libraries (quarkus-rest-jackson, quarkus-rest-jsonb).
+- **Deserialization:** Ensure accurate conversion of JSON payloads, that it's performed using the configured Quarkus JSONB library (quarkus-rest-jsonb).
 - **HTTP Status Code:** Expect `201 Created` upon successful payload processing.
 - **Response Content:** Validate that the response contains the expected message.
 
@@ -37,14 +37,14 @@ Test how the application responds to malformed or invalid JSON requests
 ensuring appropriate error responses are returned.
 - **Payload:** json file without commas between objects, extra strings, etc.
 - **HTTP Method:** `POST`
-- **HTTP Status Code:** Expect 400 Bad request for invalid payloads.
+- **HTTP Status Code:** Expect 500 Internal Server Error for invalid JSON payload.
 
 #### Handling missing or incorrect data types:
 Validate the behavior when required JSON fields are missing or have incorrect, empty, null data types,
 ensuring proper error handling.
 - **Payload:** json file with empty and null json object's fields.
 - **HTTP Method:** `POST`
-- **HTTP Status Code:** Expect 400 Bad request for incorrect or missing data types.
+- **HTTP Status Code:** Expect 500 Internal Server Error for invalid JSON payload.
 
 #### Testing with special characters JSON payload :
 Validate the application's response to JSON payload containing special characters.
@@ -68,12 +68,11 @@ Test requests with incorrect Content-Type headers should fail gracefully.
 
 ## Links to the resources
 - [Writing JSON REST Services ](https://quarkus.io/guides/rest-json)
-- [Customizing the ObjectMapper in REST Client Jackson](https://quarkus.io/guides/rest-client#customizing-the-objectmapper-in-rest-client-jackson)
 - [Creating the first JSON REST service](https://quarkus.io/guides/resteasy#creating-the-first-json-rest-service)
 
 ### Impact on resources
 - On JVM, tests increase execution time of the module http-advanced-reactive up to 1 minutes.
-- On Native, JsonJacksonPayloadIT time execution takes 03:17 min and JsonBPayloadIT 02:49 min.
+- On Native, JsonBPayloadIT 02:49 min.
 - On Openshift, tests takes 02:31 min.
 
 ## Contacts


### PR DESCRIPTION
After PR discussion and investigation that it's not possible to determine what library (quarkus-rest-jackson and quarkus-rest-jsonb) is used for serialization/deserialization , I've decided drop testing with quarkus-rest-jackson.

You can see also the comment here--> https://github.com/quarkus-qe/quarkus-test-plans/pull/179#discussion_r1680692118

### Links

JIRA:
[QQE-379](https://issues.redhat.com/browse/QQE-379)

Quarkus documentation:

  [Writing JSON REST Services ](https://quarkus.io/guides/rest-json)
    [Creating the first JSON REST service](https://quarkus.io/guides/resteasy#creating-the-first-json-rest-service)

Quarkus documentation:

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
