### PR TITLE
Add test plan for QQE-832

### DIFF
--- a/QQE-832.md
+++ b/QQE-832.md
@@ -1,0 +1,42 @@
+# QQE-832 Coverage for Quarkus Cache with Infinispan
+
+JIRA link: https://issues.redhat.com/browse/QQE-832
+
+- Quarkus guide: https://quarkus.io/guides/cache-infinispan-reference
+
+## Scope of the testing
+- The test coverage will be verified for environments: JVM and Native mode for Baremetal and Openshift.
+- Verify the `quarkus-infinispan-cache` extension using `@CacheResult`, `@CacheInvalidate`, `@CacheInvalidateAll` and `@CacheKey` caching annotations.
+- Cover different usages:
+  - from an application scoped service
+  - from a request scoped service
+  - from a blocking endpoint
+  - from a reactive endpoint
+- Use [custom POJOs](https://quarkus.io/guides/cache-infinispan-reference#marshalling-your-pojos) as cache value, verify marshalling in Quarkus Infinispan.
+- Test [cache expiration](https://quarkus.io/guides/cache-infinispan-reference#expiration) properties.
+
+## Getting familiar with the feature
+Following actions were taken to ensure familiarity:
+- Ensure documentation provides clear explanation on configuration options.
+- Ensure good user experience and simplicity of use.
+
+## Existing test coverage
+- [Quarkus integration tests infinispan-cache](https://github.com/quarkusio/quarkus/tree/main/integration-tests/infinispan-cache/src/test/java/io/quarkus/it/cache/infinispan)
+- [Quarkus extensions: infinispan-cache](https://github.com/quarkusio/quarkus/tree/main/extensions/infinispan-cache/deployment/src/test)
+
+### Impact on test suites and testing automation
+- New tests will be added to [cache](https://github.com/quarkus-qe/quarkus-test-suite/tree/main/cache) module in QQE TS.
+
+### Impact on resources
+- Baremetal JVM: 45 sec.
+- Baremetal Native: 2:45 min.
+- OpenShift JVM: 3:23 min.
+- OpenShift Native: 6:20 min.
+
+## Contacts
+- Tester: Georgii Troitskii <gtroitsk@redhat.com>
+
+## References
+
+- [Caching using annotations](https://quarkus.io/guides/cache#annotations-api)
+- [Infinispan cache](https://quarkus.io/guides/cache-infinispan-reference)


### PR DESCRIPTION
### Links

JIRA: https://issues.redhat.com/browse/QQE-832

Quarkus documentation: https://quarkus.io/guides/cache-infinispan-reference

Metrics are supported only for [Caffeine cache](https://quarkus.io/guides/cache#enabling-micrometer-metrics),  I tested it on simple app

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
