### PR TITLE
Rename QQE-1450 to QUARKUS-5870

### DIFF
--- a/QUARKUS-5870.md
+++ b/QUARKUS-5870.md
@@ -1,4 +1,4 @@
-# QQE-1450 Websocket next
+# QUARKUS-5870 Websocket next
 
 ## Scope of testing
 Verify quarkus' websocket-next extension.


### PR DESCRIPTION
### Links

JIRA: https://issues.redhat.com/browse/QUARKUS-5870

We got the umbrella JIRA for websocket next. Renaming QQE into QUARKUS designation.
