### PR TITLE
QUARKUS-5857 Remove OCP from Impact on resources section

### DIFF
--- a/QUARKUS-5857.md
+++ b/QUARKUS-5857.md
@@ -36,7 +36,7 @@ QE TS already has tests for quarkus-websocket-next introduced by QUARKUS-5870.md
 New classes and tests will be created into 'quarkus-test-suite/websockets/websocket-next-oidc'.
 
 ## Impact on resources
-Tests will be executed on both JVM and native and on both baremetal and OCP.
+Tests will be executed on JVM and native on baremetal.
 Expected additional execution time in minutes for each case.
 
 ## Contacts


### PR DESCRIPTION
This is just a small modification from https://github.com/quarkus-qe/quarkus-test-plans/pull/210, removing OCP of the impact resources as it's mentioned here--> https://github.com/quarkus-qe/quarkus-test-suite/pull/2386#issuecomment-2794343641 
