### PR TITLE
Add Test Plan for QQE-674

### DIFF
--- a/QQE-674.md
+++ b/QQE-674.md
@@ -1,0 +1,56 @@
+# QUARKUS-5866 - REST client support of TLS configuration updates
+
+JIRA: https://issues.redhat.com/browse/QQE-674
+
+Upstream issue: https://github.com/quarkusio/quarkus/issues/39677
+Upstream PR: https://github.com/quarkusio/quarkus/pull/39762
+
+Our customer reported that when a Uni operation fails (for instance, due to timeout in this case), the failured is cached.
+This causes all subsequent calls with the same cache key to return the cached failure without calling the remote service again, until the cache is invalidated.
+The fix ensures that when a Uni fails, the cache entry is invalidated and allows calls to retry the operation.
+
+## Scope of the testing
+
+Tests that failed Uni operations are not cached for all cache key generation strategies in Quarkus Cache.
+We will simulate common failures scenarios that customers could face in production environments.
+Tests will run in both JVM and native modes covering bare-metal and OpenShift deployments.
+
+### Tests will cover these scenarios
+   * Cache key generation strategies
+     - No arguments method
+     - Single argument method
+     - Multiple arguments methos
+     - Method with @CacheKey annotation
+
+   * Simulated failure scenarios
+     - Service unavailable (HTTP 503)
+     - Timeout errors
+     - Generic runtime exceptions
+     
+   * Other cases
+     - Concurrent access during failures
+     - Null values caching (should be cached)
+     - Cache invalidation after failures
+     - Cache key collisions
+
+
+## Existing test coverage
+Upstream test coverage includes a basic test in UniReturnTypeWithFailureTest that verifies failed Unis are not cached with a counter-mechanism.
+Quarkus-qe/quarkus-test-suite has cache operations coverage in the cache modules.
+
+### Impact on test suites and testing automation
+Tests will be added to the cache/caffeine module:
+- New test class: UniFailureCacheIT
+- New resource class ReactiveFailureCacheResource
+
+### Impact on resources
+Test execution time will increase, I expect increase in the test execution time roughly in 2-4 minutes.
+
+## Getting familiar with the feature
+The following actions were taken to ensure familiarity:
+- Analyzed the original issue https://github.com/quarkusio/quarkus/issues/39677
+- Review the fix implementation in PR https://github.com/quarkusio/quarkus/pull/39762
+- Take a look into cache key generation logic in a Quarkus guide https://quarkus.io/guides/cache
+
+## Contacts
+* Tester: Jose Carranza <jcarranz@redhat.com>


### PR DESCRIPTION
Add TP related to a fix [#39762](https://github.com/quarkusio/quarkus/pull/39762) to ensure that failed unis are not cached.

### Links
Jira fix : https://github.com/quarkusio/quarkus/pull/39762
Jira issue: https://github.com/quarkusio/quarkus/issues/39677

JIRA QQE: https://issues.redhat.com/browse/QQE-674

Quarkus documentation:
https://quarkus.io/guides/cache
Extension/feature community status:
https://quarkus.io/extensions/io.quarkus/quarkus-cache/ stable
### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
