### PR TITLE
Add feature test plan for QUARKUS-6292 (Extend the platform with offering) with child test plans

### DIFF
--- a/QUARKUS-6292.md
+++ b/QUARKUS-6292.md
@@ -1,0 +1,47 @@
+# QUARKUS-6292 - Extend the platform with offering
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-6292
+
+Extend the platform with offering
+
+## Scope of testing
+QUARKUS-6292 start dividing the offering by adding the offering metadata each supported extension.
+The metadata label should have format of `<offering-id>-support`, where the extension can have 0-n labels.
+
+As adding the multiple offering labels, there are 3 category which should be adjusted/checked:
+1. Quarkus registry (registry.quarkus)
+2. Code Quarkus (code.quarkus)
+3. Quarkus CLI
+
+### Quarkus registry (registry.quarkus)
+
+For registry there is no need for any update as the offering labels are part of already existing metadata.
+Currently only offering label in metadata is `redhat-support`.
+
+### Code Quarkus (code.quarkus)
+
+Update of Code Quarkus is defined in https://issues.redhat.com/browse/QUARKUS-6293.
+You can find the scope of testing and planned test development at https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6293.md
+
+### Quarkus CLI
+
+Update of Code Quarkus is defined in https://issues.redhat.com/browse/QUARKUS-6397.
+You can find the scope of testing and planned test development at https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6397.md
+
+
+## Automated test development
+
+You can find the description for the test development in these test plans:
+* Code Quarkus https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6293.md
+* Quarkus CLI https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6397.md
+
+
+## References
+- https://issues.redhat.com/browse/QUARKUS-6292
+- https://issues.redhat.com/browse/QUARKUS-6293
+- https://issues.redhat.com/browse/QUARKUS-6397
+- https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6293.md
+- https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6397.md
+
+## Contacts
+- Tester: Jakub Jedlička <jjedlick@redhat.com>

--- a/QUARKUS-6293.md
+++ b/QUARKUS-6293.md
@@ -1,0 +1,56 @@
+# QUARKUS-6293 - Show support status for the chosen product in code.quarkus
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-6293
+
+Show support status for the chosen product in code.quarkus
+
+Upstream PRs:
+- https://github.com/redhat-developer/code.quarkus.redhat.com/pull/190
+- https://github.com/redhat-developer/code.quarkus.redhat.com/issues/183
+- https://github.com/quarkusio/code.quarkus.io/pull/1656
+- https://github.com/quarkusio/code.quarkus.io/pull/1652
+
+## Scope of testing
+
+This feature is part of [QUARKUS-6292 (Extend the platform with offering)](https://issues.redhat.com/browse/QUARKUS-6292) feature.
+You can find the test plan at https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6292.md.
+
+Update of Code Quarkus is defined in https://issues.redhat.com/browse/QUARKUS-6293.
+There will be separate Code Quarkus for each offering (e.g. each offering will have own URL).
+The Code Quarkus will show the support level only for the self offering, other extensions will be marked as community.
+Newly it is possible to filter by support levels, which are defined for each offering (the support level for each offering can be different)
+
+In addition, the Code Quarkus add possibility to search for extension with some scope of support or search only for the extension without any support.
+
+
+## Automated test development
+
+The start-stop testsuite already contains the tests for Code Quarkus.
+These tests are cover only RedHat Code Quarkus, which will be used to test `redhat` offering.
+The tests for IBM Code Quarkus needs to be added.
+The IBM tests will be modification of the `CodeQuarkusSiteTest`.
+Also, the generic tests for Code Quarkus in `CodeQuarkusTest` will be executed for both RedHat and IBM Code Quarkus.
+The `CodeQuarkusTest` testing downloading the zip and executing the downloaded project.
+The url to download zip can be set using `code.quarkus.url`
+
+In addition, the tests to show only supported extension and show only unsupported extension will be implemented.
+
+The jenkins jobs will be updated to `matrixJob` to run both RedHat and IBM tests simultaneously.
+The start-stop profiles will run by default all tests except IBM tests.
+To execute IBM tests, the profile `ibm` will be added to start-stop testsuite and will exclude the RedHat specific tests.
+
+The daily tests runs only against code.quarkus.redhat.com.
+After the code.quarkus for IBM is available for public use, the daily tests will be expanded to run against the IBM code.quarkus.
+
+
+### Impact on TS and resources
+The test will be run only on baremetal in JVM mode.
+Total execution time increase should be in a few minutes maximum.
+
+
+## References
+- https://issues.redhat.com/browse/QUARKUS-6292
+- https://issues.redhat.com/browse/QUARKUS-6293
+
+## Contacts
+- Tester: Jakub Jedlička <jjedlick@redhat.com>

--- a/QUARKUS-6397.md
+++ b/QUARKUS-6397.md
@@ -1,0 +1,55 @@
+# QUARKUS-6397 - Show the support status for the chosen product in CLI tooling
+
+JIRA: https://issues.redhat.com/browse/QUARKUS-6397
+
+Show the support status for the chosen product in CLI tooling
+
+Upstream PRs:
+- https://github.com/quarkusio/quarkus/pull/49589
+- https://github.com/quarkusio/quarkus/pull/49487
+
+Documentation:
+- https://quarkus.io/guides/extension-metadata#extension-offerings
+- https://quarkus.io/guides/extension-registry-user#limiting-extension-catalog-to-an-offering
+
+## Scope of testing
+
+This feature is part of [QUARKUS-6292 (Extend the platform with offering)](https://issues.redhat.com/browse/QUARKUS-6292) feature.
+You can find the test plan at https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-6292.md.
+
+The Quarkus CLI feature is defined in https://issues.redhat.com/browse/QUARKUS-6397.
+The Quarkus CLI should be able to show which extension is part of which offering, when listing the extension.
+Documentation about definition and usage can be found in references section of this test plan.
+
+At the moment of Quarkus 3.27 the only way to add the offering is to add it to `.quarkus/config.yaml` manually.
+There is plan to add the offering using the Quarkus CLI command (https://github.com/quarkusio/quarkus/issues/49090).
+
+
+## Automated test development
+
+Quarkus CLI tests will cover the added `support-scope` option when listing the available extensions.
+These test will be added to Quarkus QE test suite in `quarkus-cli` module
+The created test will these cases:
+- No offering is selected
+- IBM offering is selected
+- RedHat offering is selected
+
+These tests will be executed only with product testing not as part of the daily runs, as they need to be run against product registry.
+At the moment there is no plan to have multiple registries for each offering so the tests can run against same registry.
+
+In addition, the test to check if `support-scope` if working will be added to `QuarkusCliExtensionsIT` to ensure executing this argument is not causing errors.
+This test will be executed as part of the daily testing.
+
+
+### Impact on TS and resources
+The test will be run only on baremetal in JVM mode.
+Total execution time increase should be in a few minutes maximum.
+
+
+## References
+- https://quarkus.io/guides/extension-metadata#extension-offerings
+- https://quarkus.io/guides/extension-registry-user#limiting-extension-catalog-to-an-offering
+- https://issues.redhat.com/browse/QUARKUS-6397
+
+## Contacts
+- Tester: Jakub Jedlička <jjedlick@redhat.com>


### PR DESCRIPTION
### Links

JIRA: https://issues.redhat.com/browse/QUARKUS-6292
JIRA: https://issues.redhat.com/browse/QUARKUS-6293
JIRA: https://issues.redhat.com/browse/QUARKUS-6397

Quarkus documentation: Not for all the features in this epic only the CLI
- https://quarkus.io/guides/extension-metadata#extension-offerings
- https://quarkus.io/guides/extension-registry-user#limiting-extension-catalog-to-an-offering

Extension/feature community status: N/A not specific extension

### Description

Adding the TP for feature https://issues.redhat.com/browse/QUARKUS-6292 which contains sub tasks.
These sub task should have separate TP and they should be linked to TP for https://issues.redhat.com/browse/QUARKUS-6292

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
