### PR TITLE
Update QUARKUS-7180 - Clarify testing for blocking Jakarta Data Repositories

### DIFF
--- a/QUARKUS-7180.md
+++ b/QUARKUS-7180.md
@@ -11,6 +11,8 @@ Previously, security annotations placed on Jakarta Data repository interfaces or
 This feature adds support for securing Jakarta Data repository with security annotations. The upstream documentation also describes limitations for generic repository methods using type variables or wildcards.
 
 ## Scope of the testing
+NOTE: Current planned testing coverage targets blocking Hibernate ORM Jakarta Data repositories only and does not include reactive Jakarta Data repositories.
+
 The testing will focus on validating that security annotations are correctly enforced on Jakarta Data repository interfaces and repository methods.
 
 The following scenarios will be covered: 


### PR DESCRIPTION
### Links

Added new note for this TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/300

Clarify that current testing is for blocking Jakarta Data repositories and does not include reactive repositories.

### Reminder for considerable topics

 - [ ] The title of the pull request and the commit title are in the form of "QUARKUS-ABC - TITLE_OF_THE_RFE"
 - [ ] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute
