### PR TITLE
Update QUARKUS-7867 - Fix impact on resources section

### DIFF
--- a/QUARKUS-7867.md
+++ b/QUARKUS-7867.md
@@ -46,7 +46,7 @@ The Keycloak realm configuration will need to be updated to support SPIFFE trust
 ### Impact on resources
 
 Tests will be executed on baremetal and OpenShift in JVM and native mode.
-The new tests reuse the existing Keycloak container, so the impact should be minimal.
+The new tests require an additional Keycloak container with SPIFFE features enabled.
 The estimated execution time increases by a few minutes.
 
 ## Getting familiar with the feature


### PR DESCRIPTION
### Links

Follow-up to https://github.com/quarkus-qe/quarkus-test-plans/pull/319

Clarify that the SPIFFE tests require an additional Keycloak container with SPIFFE features enabled, rather than reusing the existing one.

Extension/feature community status: Supported

### Reminder for considerable topics

 - [x] Make sure you have considered the following areas when preparing the test plan:

   - Logging
   - Tracing
   - Metrics
   - Security
   - OpenAPI
   - Data sources
   - Frontend
   - Qute